### PR TITLE
Update the .tmLanguage file to support {%- -%}

### DIFF
--- a/syntaxes/liquid.tmLanguage
+++ b/syntaxes/liquid.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -16,17 +16,17 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>{%\s*comment\s*%}</string>
+			<string>{%-?\s*comment\s*-?%}</string>
 			<key>end</key>
-			<string>{%\s*endcomment\s*%}</string>
+			<string>{%-?\s*endcomment\s*-?%}</string>
 			<key>name</key>
 			<string>comment.block.liquid</string>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>{{</string>
+			<string>{{-?</string>
 			<key>end</key>
-			<string>}}</string>
+			<string>-?}}</string>
 			<key>name</key>
 			<string>punctuation.output.liquid</string>
 			<key>patterns</key>
@@ -39,9 +39,9 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>{%</string>
+			<string>{%-?</string>
 			<key>end</key>
-			<string>%}</string>
+			<string>-?%}</string>
 			<key>name</key>
 			<string>punctuation.tag.liquid</string>
 			<key>patterns</key>
@@ -106,6 +106,12 @@
 				<dict>
 					<key>match</key>
 					<string>(?&lt;={%)\s*(\w+)</string>
+					<key>name</key>
+					<string>entity.name.tag.liquid</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;={%-)\s*(\w+)</string>
 					<key>name</key>
 					<string>entity.name.tag.liquid</string>
 				</dict>


### PR DESCRIPTION
The .tmLanguage file should support the syntax `{%- ... -%}`. Since this has been implemented in liquid-syntax-mode it should be supported here too.